### PR TITLE
Revert "[IMP] requeriments: Specific the version in the lib to avoid warning"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-numpy==1.14.5
+numpy


### PR DESCRIPTION
Reverts Vauxoo/account-financial-tools#15

Pinned version of `numpy` doesn't work anymore with recent versions of `pandas`:  
`pandas 1.1.0 requires numpy>=1.15.4, but you'll have numpy 1.14.5 which is incompatible.`

In addition, the version the OCA uses is not pinned.

Dummy MR: https://git.vauxoo.com/vauxoo/lodi/-/merge_requests/196