### PR TITLE
[FIX] account_move_name_sequence: Cast date to datetime for Odoo 19 compatibility

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -88,7 +88,12 @@ class AccountMove(models.Model):
                 # next_by_id(date) only applies on ir.sequence.date_range selection
                 # => we use with_context(ir_sequence_date=date).next_by_id()
                 # which applies on ir.sequence.date_range selection AND prefix
-                name = seq.with_context(ir_sequence_date=move.date).next_by_id()
+                # Odoo 19 ir_sequence._next() calls replace(tzinfo=None) on the
+                # date context, which requires a datetime object rather than a
+                # date object.
+                name = seq.with_context(
+                    ir_sequence_date=fields.Datetime.to_datetime(move.date)
+                ).next_by_id()
             move.name = name
         # Force compute of sequence_prefix and sequence_number
         self._compute_split_sequence()


### PR DESCRIPTION
In Odoo 19, the `ir.sequence._next()` method calls `.replace(tzinfo=None)` on the date context key (`ir_sequence_date`). Since `datetime.date` does not support `tzinfo` in `.replace()`, this raises a `TypeError: 'tzinfo' is an invalid keyword argument for replace()`. We cast the date context key to a `datetime.datetime` object using `fields.Datetime.to_datetime(move.date)` to prevent this issue.